### PR TITLE
Bug: Correcting sample install code

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     steps:
     - name: Typo CI (GitHub Action)
       uses: typoci/spellcheck-action@master
-      with:
+      # with:
         # A license can be purchased via:
         # https://gumroad.com/l/MvvBE
         # typo_ci_license_key: ${{ secrets.TYPO_CI_LICENSE_KEY }}

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ on:
   pull_request:
 jobs:
   spellcheck:
-    name: Typo CI
+    name: Typo CI (GitHub Action)
     runs-on: ubuntu-latest
     timeout-minutes: 4
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
-    - name: Typo CI (GitHub Action)
+    - name: TypoCheck
       uses: typoci/spellcheck-action@master
       # with:
         # A license can be purchased via:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/325384/90425145-328d9d00-e0b7-11ea-9daf-541daa062205.png)

Turns out we need to comment out with `with:` bit also.