### PR TITLE
Bug: Use correct repo name for changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-        github_changelog_generator -u TypoCI -p spellcheck-action--token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u TypoCI -p spellcheck-action-token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"


### PR DESCRIPTION
It couldn't build because I had two dashes in the repo name - whoopsie -.-