### PR TITLE
Pushing Dockerfile to GitHub Container Registry

### DIFF
--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: satackey/action-docker-layer-caching@v0.0.8
     - name: Build Latest Docker
       run: |
-        docker build . -t ghcr.io/TypoCI/spelling-action:latest
+        docker build . -t ghcr.io/typoci/spelling-action:latest
     - name: Login to GitHub Container Registry
       run: |
         echo ${GCR_TOKEN} | docker login "https://ghcr.io" --username "${GCR_USERNAME}" --password-stdin
@@ -26,4 +26,4 @@ jobs:
         GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
     - name: Push to Registry
       run: |
-        docker push ghcr.io/TypoCI/spelling-action:latest
+        docker push ghcr.io/typoci/spelling-action:latest

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -3,7 +3,7 @@ name: Publish To GitHub Container Registry
 on:
   push:
     branches:
-      #- master
+      - master
 jobs:
   publish_to_github_container_registry:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Pull Docker Layers
       run: |
-        docker pull ghcr.io/typoci/spellcheck-action:latest
+        docker pull ghcr.io/typoci/spellcheck-action
     - uses: satackey/action-docker-layer-caching@v0.0.8
     - name: Build Latest Docker
       run: |

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Pull Docker Layers
       run: |
-        docker-compose pull
+        docker pull ghcr.io/typoci/spellcheck-action:latest
     - uses: satackey/action-docker-layer-caching@v0.0.8
     - name: Build Latest Docker
       run: |
@@ -27,3 +27,4 @@ jobs:
     - name: Push to Registry
       run: |
         docker push ghcr.io/typoci/spellcheck-action:latest
+        echo "Pushed up"

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -20,7 +20,7 @@ jobs:
         docker build . -t typo-ci-spelling-action:latest
     - name: Login to GitHub Container Registry
       run: |
-        docker login "https://ghcr.io" --username "${GCR_USERNAME}" --password "${GCR_TOKEN}
+        docker login "https://ghcr.io" --username "${GCR_USERNAME}" --password "${GCR_TOKEN}"
       env:
         GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
         GCR_TOKEN: ${{ secrets.GCR_TOKEN }}

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Pull Docker Layers
       run: |
-        docker pull ghcr.io/typoci/spellcheck-action
+        docker pull typoci/spellcheck-action:latest
     - uses: satackey/action-docker-layer-caching@v0.0.8
     - name: Build Latest Docker
       run: |

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -3,7 +3,7 @@ name: Publish To GitHub Container Registry
 on:
   push:
     branches:
-      - master
+      #- master
 jobs:
   publish_to_github_container_registry:
     runs-on: ubuntu-latest
@@ -17,7 +17,7 @@ jobs:
     - uses: satackey/action-docker-layer-caching@v0.0.8
     - name: Build Latest Docker
       run: |
-        docker build . -t ghcr.io/typoci/spelling-action:latest
+        docker build . -t ghcr.io/typoci/spellcheck-action:latest
     - name: Login to GitHub Container Registry
       run: |
         echo ${GCR_TOKEN} | docker login "https://ghcr.io" --username "${GCR_USERNAME}" --password-stdin
@@ -26,4 +26,4 @@ jobs:
         GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
     - name: Push to Registry
       run: |
-        docker push ghcr.io/typoci/spelling-action:latest
+        docker push ghcr.io/typoci/spellcheck-action:latest

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -14,7 +14,6 @@ jobs:
     - name: Pull Docker Layers
       run: |
         docker pull typoci/spellcheck-action:latest
-    - uses: satackey/action-docker-layer-caching@v0.0.8
     - name: Build Latest Docker
       run: |
         docker build . -t ghcr.io/typoci/spellcheck-action:latest

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -1,0 +1,29 @@
+name: Publish To GitHub Container Registry
+
+on:
+  push:
+    branches:
+      #- master
+jobs:
+  publish_to_github_container_registry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Pull Docker Layers
+      run: |
+        docker-compose pull
+    - uses: satackey/action-docker-layer-caching@v0.0.8
+    - name: Build Latest Docker
+      run: |
+        docker build . -t typo-ci-spelling-action:latest
+    - name: Login to GitHub Container Registry
+      run: |
+        docker login "https://ghcr.io" --username "${GCR_USERNAME}" --password "${GCR_TOKEN}
+      env:
+        GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
+        GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
+    - name: Push to Registry
+      run: |
+        docker push typo-ci-spelling-action:latest

--- a/.github/workflows/publish_to_github_container_registry.yml
+++ b/.github/workflows/publish_to_github_container_registry.yml
@@ -17,13 +17,13 @@ jobs:
     - uses: satackey/action-docker-layer-caching@v0.0.8
     - name: Build Latest Docker
       run: |
-        docker build . -t typo-ci-spelling-action:latest
+        docker build . -t ghcr.io/TypoCI/spelling-action:latest
     - name: Login to GitHub Container Registry
       run: |
-        docker login "https://ghcr.io" --username "${GCR_USERNAME}" --password "${GCR_TOKEN}"
+        echo ${GCR_TOKEN} | docker login "https://ghcr.io" --username "${GCR_USERNAME}" --password-stdin
       env:
         GCR_USERNAME: ${{ secrets.GCR_USERNAME }}
         GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
     - name: Push to Registry
       run: |
-        docker push typo-ci-spelling-action:latest
+        docker push ghcr.io/TypoCI/spelling-action:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ LABEL com.github.actions.name="Typo CI - Spellcheck Action" \
       com.github.actions.description="Check for typos & spelling mistakes, then displays suggestions." \
       com.github.actions.icon="code" \
       com.github.actions.color="green" \
+      org.opencontainers.image.authors="Mike Rogers <me@mikerogers.io>" \
+      org.opencontainers.image.url="https://github.com/TypoCI/spellcheck-action" \
+      org.opencontainers.image.documentation="https://github.com/TypoCI/spellcheck-action" \
+      org.opencontainers.image.vendor="TypoCI" \
+      org.opencontainers.image.description="Check for typos & spelling mistakes, then displays suggestions." \
       maintainer="Mike Rogers <me@mikerogers.io>"
 
 RUN apk --no-cache add build-base git hunspell tzdata libffi-dev yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM ruby:2.7.1-alpine AS builder
-LABEL maintainer="Mike Rogers <me@mikerogers.io>"
+
+LABEL com.github.actions.name="Typo CI - Spellcheck Action" \
+      com.github.actions.description="Check for typos & spelling mistakes, then displays suggestions." \
+      com.github.actions.icon="code" \
+      com.github.actions.color="green" \
+      maintainer="Mike Rogers <me@mikerogers.io>"
 
 RUN apk --no-cache add build-base git hunspell tzdata libffi-dev yarn
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: 'docker'
   # image: 'Dockerfile'
-  image: 'docker://typoci/spellcheck-action'
+  image: 'docker://ghcr.io/typoci/spelling-action:latest'
 
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: 'docker'
   # image: 'Dockerfile'
-  image: 'docker://typoci/spellcheck-action:latest'
+  image: 'docker://typoci/spellcheck-action'
 
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: 'docker'
   # image: 'Dockerfile'
-  image: 'docker://typoci/spelling-action:latest'
+  image: 'docker://typoci/spellcheck-action:latest'
 
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: 'docker'
   # image: 'Dockerfile'
-  image: 'docker://ghcr.io/typoci/spelling-action:latest'
+  image: 'docker://typoci/spelling-action:latest'
 
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN


### PR DESCRIPTION
https://github.blog/2020-09-01-introducing-github-container-registry/ - It might be a little faster then DockerHub, so experimenting with it 👍 

# Results

So it doesn't make a big difference (Like 1s faster), but GitHub Container Registry does appear to be favoured by GitHub, so using it won't do much harm. 