### PR TITLE
Adds alternate spellings for parameterise in word list 

### DIFF
--- a/db/dict/contextual/misc.dic
+++ b/db/dict/contextual/misc.dic
@@ -598,3 +598,5 @@ rdsadmin
 gunicorn
 bzip
 libffi-dev
+parameterise/DBnGS
+parameterize/SGBnDN

--- a/db/dict/imported/en_GB.dic
+++ b/db/dict/imported/en_GB.dic
@@ -59065,11 +59065,9 @@ parament/SM
 paramesonephric
 parameter/W1pMS
 parametrise/DBnGS
-parameterise/DBnGS
 parametritis
 parametrium
 parametrize/SGBnDN
-parameterize/SGBnDN
 parametron
 paramilitarism
 paramilitary/S

--- a/db/dict/imported/en_GB.dic
+++ b/db/dict/imported/en_GB.dic
@@ -59065,11 +59065,11 @@ parament/SM
 paramesonephric
 parameter/W1pMS
 parametrise/DBnGS
-parameterise
+parameterise/DBnGS
 parametritis
 parametrium
 parametrize/SGBnDN
-parameterize
+parameterize/SGBnDN
 parametron
 paramilitarism
 paramilitary/S

--- a/db/dict/imported/en_GB.dic
+++ b/db/dict/imported/en_GB.dic
@@ -59065,9 +59065,11 @@ parament/SM
 paramesonephric
 parameter/W1pMS
 parametrise/DBnGS
+parameterise
 parametritis
 parametrium
 parametrize/SGBnDN
+parameterize
 parametron
 paramilitarism
 paramilitary/S


### PR DESCRIPTION
Hi @MikeRogers0 

Great work with the Typo-CI - it works v well and has helped me out quite a few times.

Feel like a bit of spelling Nazi, but in one of the PRs I recently reviewed I found that `parameterise` was picked up by typo-ci when it shouldn't have, as it is a valid spelling of the word.
 Checked the imported en_GB dict and found the spellings without the e (e.g parametrise )were the only ones there, so thought it would be a good idea to add the alternate spellings.

Many thanks