### PR TITLE
Adding support for Turkish

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can tweak how Typo CI analyses your code by adding a `.typo-ci.yml` file to 
 # it
 # pt
 # pt_BR
+# tr
 dictionaries:
   - en
   - en_GB

--- a/app/lib/spellcheck/configuration.rb
+++ b/app/lib/spellcheck/configuration.rb
@@ -29,6 +29,7 @@ class Spellcheck::Configuration
             it
             pt
             pt_BR
+            tr
           ]
         }
       },

--- a/app/lib/spellcheck/dictionaries.rb
+++ b/app/lib/spellcheck/dictionaries.rb
@@ -21,6 +21,7 @@ class Spellcheck::Dictionaries
       'it' => FFI::Hunspell.dict('dictionary-it/index'),
       'pt' => FFI::Hunspell.dict('dictionary-pt/index'),
       'pt_BR' => FFI::Hunspell.dict('pt_BR'),
+      'tr' => FFI::Hunspell.dict('dictionary-tr/index'),
       'combined' => FFI::Hunspell.dict('combined')
     }
   end

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dictionary-es": "^3.0.1",
     "dictionary-fr": "^2.4.1",
     "dictionary-it": "^1.3.2",
-    "dictionary-pt": "^2.0.0"
+    "dictionary-pt": "^2.0.0",
+    "dictionary-tr": "^1.3.4"
   },
   "version": "0.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,3 +36,8 @@ dictionary-pt@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/dictionary-pt/-/dictionary-pt-2.0.1.tgz#db712c4e41a8b7f224dab7026dcaf1d3ef0bc174"
   integrity sha512-DmZ2mF6aF/523yKkethhA3gpQ9Kwp8/dv6H1/naWvxzjV1Csf5k3tHYTskQihWPpf+sYF5Z3rcl2waRi+aWbOg==
+
+dictionary-tr@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/dictionary-tr/-/dictionary-tr-1.3.4.tgz#fdc5963b388ea5a8e41eb5c8e39627c11d2544bb"
+  integrity sha512-WcDWKhqgedsKG++2P9PnhFqdc6iYwUVKEGZP7AsfdBGSR+pCQYHF2Rh5b7+lF2EaCxik8zMPiqDwtUk9CeF1jw==


### PR DESCRIPTION
This adds the Turkish dictionary in. You can enable it by updating your `.typo-ci.yml` file to be:

```yml
---
dictionaries:
  - en
  - en_GB
  - tr
```