### PR TITLE
Blocking bot users from trigger actions

### DIFF
--- a/app/models/github/check_suite.rb
+++ b/app/models/github/check_suite.rb
@@ -1,7 +1,7 @@
 class Github::CheckSuite < ApplicationRecord
-  BlockedAuthors = [
-    'tensorflow-copybara',
-    'gatsbybot',
+  BlockedAuthors = %w[
+    tensorflow-copybara
+    gatsbybot
   ].freeze
 
   attr_accessor :github_token,

--- a/app/models/github/check_suite.rb
+++ b/app/models/github/check_suite.rb
@@ -1,18 +1,7 @@
 class Github::CheckSuite < ApplicationRecord
   BlockedAuthors = [
-    'pull[bot]',
     'tensorflow-copybara',
-    'restyled-io[bot]',
-    'github-actions[bot]',
-    'renovate[bot]',
-    'dependabot-preview[bot]',
-    'dependabot[bot]',
-    'depfu[bot]',
-    'imgbot[bot]',
-    'github-actions[bot]',
     'gatsbybot',
-    'greenkeeper[bot]',
-    'allcontributors[bot]'
   ].freeze
 
   attr_accessor :github_token,
@@ -94,6 +83,6 @@ class Github::CheckSuite < ApplicationRecord
   private
 
   def actor_banned?
-    actor.in?(BlockedAuthors)
+    sender_type == 'Bot' || actor.in?(BlockedAuthors)
   end
 end

--- a/spec/factories/github/check_suites.rb
+++ b/spec/factories/github/check_suites.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
 
     trait :bot_commit do
       actor { 'pull[bot]' }
+      sender_type { 'Bot' }
     end
 
     trait :pull_request do

--- a/spec/jobs/github/check_suites/requested_job_spec.rb
+++ b/spec/jobs/github/check_suites/requested_job_spec.rb
@@ -39,5 +39,14 @@ RSpec.describe Github::CheckSuites::RequestedJob, type: :job do
         subject
       end
     end
+
+    context "check suite is made by bot user" do
+      let(:github_check_suite) { build(:github_check_suite, :bot_commit) }
+
+      it 'Does not queue up AnalysisJob' do
+        expect(Github::CheckSuites::AnalysisJob).to_not receive(:perform_now)
+        subject
+      end
+    end
   end
 end

--- a/spec/jobs/github/check_suites/requested_job_spec.rb
+++ b/spec/jobs/github/check_suites/requested_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Github::CheckSuites::RequestedJob, type: :job do
       end
     end
 
-    context "check suite is made by bot user" do
+    context 'check suite is made by bot user' do
       let(:github_check_suite) { build(:github_check_suite, :bot_commit) }
 
       it 'Does not queue up AnalysisJob' do


### PR DESCRIPTION
I noticed playing wack-a-mole with specific users creating commits will be unsustainable long term. So I decided I should block all commits made by Bots from triggering the workflow.

The reason for this is if Bots could potentially create enough commits to use up a users quota. Which could be rather expensive if left unchecked.