### PR TITLE
Encourage running on "push" over "pull_request"

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,9 +3,6 @@ name: RSpec
 
 on:
   push:
-    branches: 
-      - master
-  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -2,9 +2,8 @@ name: Typo CI
 
 on:
   push:
-    branches:
+    branches-ignore:
       - master
-  pull_request:
 jobs:
   spellcheck:
     name: Typo CI (GitHub Action)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ name: Typo CI
 
 on:
   push:
-    branches:
+    branches-ignore:
       - master
-  pull_request:
 jobs:
   spellcheck:
     name: Typo CI (GitHub Action)


### PR DESCRIPTION
Running on `pull_request` can feel a bit slower compared to `push`, so encouraging users to use push.

Also encouraging people to not run on their `master` branch, as they'll probably only want to see the changes in a PR.