### PR TITLE
Only tracking major version tag for GitHub Actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,11 +12,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1.1.2
+    - name: Set up Ruby 2.7
+      uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
-    - uses: actions/cache@v2.1.2
+        ruby-version: 2.7
+    - uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Pull docker images
         run: |
           docker pull ruby:2.7.1-alpine
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: satackey/action-docker-layer-caching@v0
       - name: Build the latest image
         run: |
           docker build . -t typo-ci-spelling-action:latest

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: Cache gems
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
Most the Dependabot PRs around GitHub Actions are minor bumps, which are kind of annoying. I'm got to stick with just tracking the major versions.