### PR TITLE
Adding support for .typo-ci.yml within .github folder

### DIFF
--- a/.github/.typo-ci.yml
+++ b/.github/.typo-ci.yml
@@ -1,0 +1,26 @@
+---
+
+dictionaries:
+  - en
+  - en_GB
+
+# Any files/folders we should ignore?
+excluded_files:
+  - "vendor/**/*"
+  - "node_modules/**/*"
+  - "*.key"
+  - "*.enc"
+  - "*.min.css"
+  - "*.css.map"
+  - "*.min.js"
+  - "*.js.map"
+  - "*.mk"
+  - "package-lock.json"
+  - "yarn.lock"
+  - "Gemfile.lock"
+  - ".typo-ci.yml"
+
+excluded_words:
+  - typoci
+
+spellcheck_filenames: true

--- a/README.md
+++ b/README.md
@@ -49,14 +49,15 @@ jobs:
 
 ## Configuration
 
-You can tweak how Typo CI analyses your code by adding a `.typo-ci.yml` file to the root of your repository. Here is a sample file:
+You can tweak how Typo CI analyses your code by adding a `.typo-ci.yml` file to the root of your repository (You can also add it within your `.github` folder). Here is a sample file:
 
 ```yml
 # This is a sample .typo-ci.yml file, it's used to configure how Typo CI will behave.
 # Add it to the root of your project and push it to github.
 ---
 
-# What language dictionaries should it use? Currently Typo CI supports:
+# What language dictionaries should it use? By default Typo CI will select 'en' & 'en_GB'
+# Currently Typo CI supports:
 # de
 # en
 # en_GB

--- a/app/services/github/repositories/analysis_service.rb
+++ b/app/services/github/repositories/analysis_service.rb
@@ -61,6 +61,8 @@ class Github::Repositories::AnalysisService
   def configuration_options
     if @repository_path.join('.typo-ci.yml').exist?
       YAML.safe_load(@repository_path.join('.typo-ci.yml').read)
+    elsif @repository_path.join('.github/.typo-ci.yml').exist?
+      YAML.safe_load(@repository_path.join('.github/.typo-ci.yml').read)
     else
       {}
     end


### PR DESCRIPTION
Closes https://github.com/TypoCI/spellcheck-action/issues/90

This allows users to place the `.typo-ci.yml` file within the repos `.github` folder.