### PR TITLE
Adding support for Dutch (nl) language

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can tweak how Typo CI analyses your code by adding a `.typo-ci.yml` file to 
 # es
 # fr
 # it
+# nl
 # pt
 # pt_BR
 # tr

--- a/app/lib/spellcheck/configuration.rb
+++ b/app/lib/spellcheck/configuration.rb
@@ -27,6 +27,7 @@ class Spellcheck::Configuration
             es
             fr
             it
+            nl
             pt
             pt_BR
             tr

--- a/app/lib/spellcheck/dictionaries.rb
+++ b/app/lib/spellcheck/dictionaries.rb
@@ -19,6 +19,7 @@ class Spellcheck::Dictionaries
       'es' => FFI::Hunspell.dict('dictionary-es/index'),
       'fr' => FFI::Hunspell.dict('dictionary-fr/index'),
       'it' => FFI::Hunspell.dict('dictionary-it/index'),
+      'nl' => FFI::Hunspell.dict('dictionary-nl/index'),
       'pt' => FFI::Hunspell.dict('dictionary-pt/index'),
       'pt_BR' => FFI::Hunspell.dict('pt_BR'),
       'tr' => FFI::Hunspell.dict('dictionary-tr/index'),

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dictionary-es": "^3.0.1",
     "dictionary-fr": "^2.4.1",
     "dictionary-it": "^1.3.2",
+    "dictionary-nl": "^1.4.0",
     "dictionary-pt": "^2.0.0",
     "dictionary-tr": "^1.3.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,11 @@ dictionary-it@^1.3.2:
   resolved "https://registry.yarnpkg.com/dictionary-it/-/dictionary-it-1.3.3.tgz#45b1788fe015cbfdc04c6255745d73725fd4905a"
   integrity sha512-hGpvCRhbHpqkYRZJx6VapB3G20EsbY87KX8xhU4E9SaPxYhIzYHnYD22826hU0JSh2OAHuvSlkwCxsnI2PFO6g==
 
+dictionary-nl@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dictionary-nl/-/dictionary-nl-1.4.0.tgz#80cf84da1c3a65f605e424f0951c3f988fff5260"
+  integrity sha512-JSaHXU0aAb9QZqdp6p4q0QSlbzl9pbRuZtBNHjBwGf4brKzRzyiae6/SKh2M4UG/sF2UZ/qnN056zJbDcFJqtA==
+
 dictionary-pt@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/dictionary-pt/-/dictionary-pt-2.0.1.tgz#db712c4e41a8b7f224dab7026dcaf1d3ef0bc174"


### PR DESCRIPTION
Closes #111

# Summary

This add in the `dictionary-nl` dependency, which adds support for the Dutch language. You can enable it adding `nl` to the dictionaries list in your `.typo-ci.yml` file, e.g:

```yml
dictionaries:
  - nl
```

# Thank you!

Thank you @krtschmr - Sorry for not responding sooner! This is a really awesome suggestion :)