### PR TITLE
Locking github_changelog_generator to 1.15.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,7 @@ jobs:
           ${{ runner.os }}-changelog-gem-
     - name: Create local changes
       run: |
-        gem install github_changelog_generator
+        gem install github_changelog_generator -v "1.15.2"
         github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |


### PR DESCRIPTION
Currently the changelog generator isn't working due to an bug in the latest release. So locking it to the last working version.